### PR TITLE
Release/1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mtgcb-price-service",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "MTG CB's Price Service",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "mtgcb-price-service",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "MTG CB's Price Service",
   "main": "index.js",
   "scripts": {
     "build": "babel src -d dist",
-    "start": "yarn build && node -r dotenv/config dist/index.js",
+    "start": "node -r dotenv/config dist/index.js",
     "dev": "nodemon --exec babel-node -r dotenv/config src/index.js",
-    "test": "yarn build && jest --setupFiles dotenv/config",
-    "serve": "node dist/index.js"
+    "test": "yarn build && jest --setupFiles dotenv/config"
   },
   "author": "Brian Chuchua",
   "license": "MIT",

--- a/src/__tests__/network/tcgplayer/getTcgplayerPricesForCard.test.js
+++ b/src/__tests__/network/tcgplayer/getTcgplayerPricesForCard.test.js
@@ -2,10 +2,6 @@ import axios from 'axios';
 import { getTcgplayerPricesForCard } from '../../../network/tcgplayer';
 import { TCGPLAYER_CARD_PRICE_PREFIX, TCGPLAYER_TOKEN } from '../../../constants/cacheKeys';
 
-// jest.mock('../../../network/tcgplayer/getTcgplayerToken', () => ({
-//   getTcgplayerToken: jest.fn(() => 'mock-token'),
-// }));
-
 jest.mock('axios', () => ({
   get: jest.fn(() => ({
     data: {

--- a/src/constants/cacheKeys.js
+++ b/src/constants/cacheKeys.js
@@ -1,5 +1,7 @@
 export const ALL_CARDS = 'cards:all';
 export const ALL_PRICES = 'prices:all';
 
+export const ALL_CARDS_FROM_ID_PREFIX = 'cards:from_id';
+
 export const TCGPLAYER_TOKEN = 'tcgplayer:token';
 export const TCGPLAYER_CARD_PRICE_PREFIX = 'tcgplayer:price';

--- a/src/databases/priceServiceDb.js
+++ b/src/databases/priceServiceDb.js
@@ -1,5 +1,5 @@
 import keyBy from 'lodash/keyBy';
-import { ALL_CARDS, ALL_PRICES } from '../constants/cacheKeys';
+import { ALL_CARDS, ALL_PRICES, ALL_CARDS_FROM_ID_PREFIX } from '../constants/cacheKeys';
 
 export const getConnectionToPriceServiceDatabase = async (knex) => {
   try {
@@ -32,6 +32,26 @@ export const getAllCardsFromPriceServiceDatabase = async (
       return {};
     }
   }
+  return cards;
+};
+
+export const getAllCardsFromPriceServiceDatabaseFromId = async (
+  databaseConnection,
+  cache,
+  options = { startId: 1 }
+) => {
+  const ALL_CARDS_FROM_ID = `${ALL_CARDS_FROM_ID_PREFIX}:${options.startId}`;
+
+  let cards = cache.get(ALL_CARDS_FROM_ID);
+  try {
+    cards = await databaseConnection.from('Card').where('id', '>=', options.startId);
+    cards = keyBy(cards, 'id');
+    cache.set(ALL_CARDS_FROM_ID, cards);
+  } catch (error) {
+    console.error(`[Error] Failed to getAllCardsFromPriceServiceDatabaseFromId: ${JSON.stringify(error)}`);
+    return {};
+  }
+
   return cards;
 };
 

--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -1,4 +1,5 @@
 import updateAllPrices from './updateAllPrices';
 import updateAllCardsLegacy from './updateAllCardsLegacy';
+import updatePricesStartingFromId from './updatePricesStartingFromId';
 
-export { updateAllPrices, updateAllCardsLegacy };
+export { updateAllPrices, updateAllCardsLegacy, updatePricesStartingFromId };

--- a/src/jobs/updatePricesStartingFromId.js
+++ b/src/jobs/updatePricesStartingFromId.js
@@ -1,0 +1,78 @@
+import cliProgress from 'cli-progress';
+import { getAllCardsFromPriceServiceDatabaseFromId, upsertPriceIntoDatabase } from '../databases/priceServiceDb';
+import { getTcgplayerPricesForCard } from '../network/tcgplayer';
+import { warmUpPriceCache } from './util';
+
+const updatePricesStartingFromId = async (db, cache, startId) => {
+  if (startId == null) {
+    console.error(`[Error] Failed to updatePricesStartingFromId -- startId was missing`);
+    return null;
+  }
+
+  const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+  const startTime = new Date().getTime();
+  console.info(`[Info] Started price update from id = ${startId} at ${new Date(startTime).toISOString()}`);
+
+  const cards = await getAllCardsFromPriceServiceDatabaseFromId(db, cache, { startId });
+  const listOfCards = Object.values(cards);
+  const cardCount = listOfCards.length;
+  progressBar.start(cardCount, 0);
+
+  const pricesToFetch = [];
+  for (const card of listOfCards) {
+    pricesToFetch.push(
+      getTcgplayerPricesForCard(card, cache).finally(() => {
+        progressBar.increment();
+      })
+    );
+  }
+
+  const allPrices = (
+    await Promise.allSettled(pricesToFetch).finally(() => {
+      progressBar.stop();
+    })
+  )
+    .filter((price) => price?.value)
+    .map((price) => price?.value);
+
+  const pricesToInsert = allPrices.map((allCardPriceEntries) => {
+    const priceToInsert = {};
+    for (const specificCardPriceEntries of Object.values(allCardPriceEntries)) {
+      for (const priceEntry of specificCardPriceEntries) {
+        if (priceEntry.subTypeName === 'Normal') {
+          priceToInsert.cardId = priceEntry.cardId;
+          priceToInsert.tcgplayerId = priceEntry.productId;
+          priceToInsert.low = priceEntry.lowPrice;
+          priceToInsert.average = priceEntry.midPrice;
+          priceToInsert.high = priceEntry.highPrice;
+          priceToInsert.market = priceEntry.marketPrice;
+        } else if (priceEntry.subTypeName === 'Foil') {
+          if (priceEntry.marketPrice) {
+            priceToInsert.foil = priceEntry.marketPrice;
+          } else if (priceEntry.lowPrice) {
+            priceToInsert.foil = priceEntry.lowPrice;
+          } else {
+            priceToInsert.foil = null;
+          }
+        }
+      }
+    }
+    return priceToInsert;
+  });
+
+  for (const priceToInsert of pricesToInsert) {
+    await upsertPriceIntoDatabase(priceToInsert, db);
+  }
+
+  const endTime = new Date().getTime();
+  const duration = (endTime - startTime) / 1000 / 60;
+  console.info(
+    `[Info] Ended price update from id = ${startId} at ${new Date(endTime).toISOString()}. Duration: ${duration.toFixed(
+      2
+    )} minutes`
+  );
+
+  await warmUpPriceCache(db, cache);
+};
+
+export default updatePricesStartingFromId;

--- a/src/loaders/setUpRoutes.js
+++ b/src/loaders/setUpRoutes.js
@@ -1,10 +1,11 @@
 import route from 'koa-route';
-import { getPrice, getPrices, healthCheck } from '../routes';
+import { getPrice, getPrices, healthCheck, updatePrices } from '../routes';
 
 const setUpRoutes = (app) => {
   app.use(route.get('/prices/:id', getPrice));
   app.use(route.get('/prices/', getPrices));
   app.use(route.get('/health/', healthCheck));
+  app.use(route.post('/jobs/prices/:startId', updatePrices));
 };
 
 export default setUpRoutes;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 import getPrice from './getPrice';
 import getPrices from './getPrices';
 import healthCheck from './healthCheck';
+import updatePrices from './updatePrices';
 
-export { getPrice, getPrices, healthCheck };
+export { getPrice, getPrices, healthCheck, updatePrices };

--- a/src/routes/updatePrices.js
+++ b/src/routes/updatePrices.js
@@ -1,0 +1,21 @@
+import { updatePricesStartingFromId } from '../jobs';
+
+const updatePrices = (ctx, startId) => {
+  if (startId == null) {
+    ctx.status = 400;
+    ctx.body = { error: `startId is required, received: ${startId}` };
+  } else {
+    try {
+      updatePricesStartingFromId(ctx.db, ctx.cache, startId);
+      ctx.status = 200;
+      ctx.body = { message: `updatePricesStartingFromId job queued from id ${startId}` };
+    } catch (error) {
+      ctx.status = 503;
+      ctx.body = {
+        error: `Unable to queue job updatePricesStartingFromId from id ${startId}: ${JSON.stringify(error)}`,
+      };
+    }
+  }
+};
+
+export default updatePrices;


### PR DESCRIPTION
Adds a new route to trigger a job to update all card prices starting with a particular `id`.

This was useful to me since, when adding new cards to the website, there's a need to update just them.

Improved test coverage will be coming once I decide on my CI/CD vendor.